### PR TITLE
0.2.11.5: Functions on edges can use "=~" to denote loadings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: semptools
 Title: Customizing Structural Equation Modelling Plots
-Version: 0.2.11.4
+Version: 0.2.11.5
 Authors@R: c(
     person(given = "Shu Fai",
            family = "Cheung",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# semptools 0.2.11.4
+# semptools 0.2.11.5
 
 ## New Features
 
@@ -50,6 +50,14 @@
   standardized solution standard errors
   by setting the argument `std_type`.
   (0.2.11.3)
+
+- Functions that change the attributes
+  of an edge, such as `set_edge_label_position()`,
+  should now supports factor loadings by
+  using the `=~` operator when specifying
+  the edge. Previously, we needed to specify
+  a loading as if it were a regression
+  path (e.g., `x1 ~ f1`). (0.2.11.5)
 
 ## Miscellaneous
 

--- a/R/to_list_of_lists.R
+++ b/R/to_list_of_lists.R
@@ -47,7 +47,12 @@ to_list_of_lists <- function(input, name1 = NULL,
     if (split_name) {
         input_names_split_i <- function(x) {
             out <- lavaan::lavParseModelString(x)
-            out <- c(rhs = out$rhs, lhs = out$lhs)
+            # Handle factor loadings
+            if (identical(out$op, "=~")) {
+                out <- c(rhs = out$lhs, lhs = out$rhs)
+              } else {
+                out <- c(rhs = out$rhs, lhs = out$lhs)
+              }
           }
         input_names_split <- lapply(input_names, input_names_split_i)
         input_names_rhs <- sapply(input_names_split, getElement, name = "rhs")
@@ -69,18 +74,18 @@ to_list_of_lists <- function(input, name1 = NULL,
     input_noname <- input
     names(input_noname) <- NULL
     if (is.null(input_names_lhs)) {
-        out <- mapply(tmpfct, input_names_rhs, 
+        out <- mapply(tmpfct, input_names_rhs,
                               input_noname,
-                              MoreArgs = 
+                              MoreArgs =
                                 list(out_names = out_names),
                               SIMPLIFY = FALSE,
                               USE.NAMES = FALSE
                               )
       } else {
-        out <- mapply(tmpfct, input_names_rhs, 
-                              input_names_lhs, 
+        out <- mapply(tmpfct, input_names_rhs,
+                              input_names_lhs,
                               input_noname,
-                              MoreArgs = 
+                              MoreArgs =
                                 list(out_names = out_names),
                               SIMPLIFY = FALSE,
                               USE.NAMES = FALSE

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![R-CMD-check](https://github.com/sfcheung/semptools/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/sfcheung/semptools/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-(Version 0.2.11.4, updated on 2024-10-17, [release history](https://sfcheung.github.io/semptools/news/index.html))
+(Version 0.2.11.5, updated on 2024-10-20, [release history](https://sfcheung.github.io/semptools/news/index.html))
 
 # semptools <img src="man/figures/logo.png" align="right" height="150" />
 

--- a/tests/testthat/test-set_edge_attribute_loadings.R
+++ b/tests/testthat/test-set_edge_attribute_loadings.R
@@ -1,0 +1,41 @@
+library(lavaan)
+library(semPlot)
+
+# CFA
+
+mod <-
+  'f1 =~ x01 + x02 + x03
+   f2 =~ x04 + x05 + x06 + x07
+   f3 =~ x08 + x09 + x10
+   f4 =~ x11 + x12 + x13 + x14
+  '
+fit <- lavaan::cfa(mod, cfa_example, orthogonal = TRUE)
+p <- semPaths(fit,
+              whatLabels = "est",
+              sizeMan = 3.25,
+              node.width = 1,
+              edge.label.cex = .75,
+              mar = c(10, 5, 10, 5),
+              exoCov = FALSE,
+              DoNotPlot = TRUE)
+p2 <- set_cfa_layout(p)
+plot(p2)
+p3 <- set_edge_attribute(p2, c("f4 =~ x11" = "red"),
+                         attribute_name = "color") |>
+      set_edge_attribute(c("f4 =~ x11" = 5),
+                         attribute_name = "width") |>
+      set_edge_attribute(c("f4 =~ x11" = .2),
+                         attribute_name = "edge.label.position")
+plot(p3)
+p3_chk <- set_edge_label_position(p2,
+                                  position_list = c("x11 ~ f4" = .2)) |>
+          set_edge_color(c("x11 ~ f4" = "red"))
+plot(p3_chk)
+
+test_that("set_edge_attribute: loadings", {
+    expect_equal(p3$graphAttributes$Edges$edge.label.position,
+                 p3_chk$graphAttributes$Edges$edge.label.position)
+    expect_equal(p3$graphAttributes$Edges$color,
+                 p3_chk$graphAttributes$Edges$color)
+  })
+


### PR DESCRIPTION
Tests, checks, and build_site() passed.
(Previously, need to treat them as regression paths, e.g., `x1 ~ f1`.